### PR TITLE
Added Space to semicolon mapping

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -12,6 +12,7 @@ set number
 
 "Mappings
 nnoremap ; :
+nnoremap <Space> ;
 
 "Filetype on
 filetype on


### PR DESCRIPTION
@DepthDeluxe What do you think? Space originally just moves your cursor to the next character, which is easily done with `l`. It's a large key, might as well make use of it!

Now, space `repeats latest f, t, F or T [count] times. See cpo-;` according to the vim docs. It would be cool if this included `d` though.